### PR TITLE
Add workflow for go-test

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,38 @@
+# Copyright 2024 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Go Test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:20.10.12-dind
+        ports:
+          - 2375:2375
+          - 9094:9094
+          - 27017:27017
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.21
+
+    - name: Run go test
+      env:
+        KAFKA_HOST: localhost:9094
+        KAFKA_IMAGE: bitnami/kafka
+        KAFKA_TAG: 3.4.1
+        MONGO_HOST: localhost:27017
+        MONGO_IMAGE: mongo
+        MONGO_TAG: 7.0.5-rc0
+      run: go test -v ./...

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -10,6 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .fleet
 
 *.yml
+!.github/workflows/*.yml
 !.gitlab-ci.yml
 !docker-compose.yml
 *.exe


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow for the `go test` command while providing a dind service for running Kafka and MongoDB.