### PR TITLE
Add conventional commit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,12 @@ repos:
       rev: v1.0.0
       hooks:
         - id: reuse
+          stages:
+            - pre-commit
+  -   repo: https://github.com/compilerla/conventional-pre-commit
+      rev: v3.1.0
+      hooks:
+        - id: conventional-pre-commit
+          stages:
+           - commit-msg
+          args: []


### PR DESCRIPTION
This PR contains an update to the `.pre-commit-config.yaml` to ensure conventional commit formatting according to https://www.conventionalcommits.org/en/v1.0.0/.