### PR TITLE
Remove docker mirror from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM dockerhub.devops.telekom.de/golang:1.21-alpine AS build
+FROM golang:1.21-alpine AS build
 ARG GOPROXY
 ARG GONOSUMDB
 ENV GOPROXY=$GOPROXY

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ SPDX-License-Identifier: Apache-2.0
   A connector for transferring and transforming data from Kafka to MongoDB.
 </p>
 
+[![REUSE status](https://api.reuse.software/badge/github.com/telekom/pubsub-horizon-vortex)](https://api.reuse.software/info/github.com/telekom/pubsub-horizon-vortex)
+[![Go Test](https://github.com/telekom/pubsub-horizon-vortex/actions/workflows/go-test.yml/badge.svg)](https://github.com/telekom/pubsub-horizon-vortex/actions/workflows/go-test.yml)
+
 ## Overview
 Vortex is a connector for transferring and transforming data from Kafka to MongoDB. It is custom tailored for the data 
 produced and processed by Horizon.


### PR DESCRIPTION
This PR removes the docker mirror from the build image path.