### PR TITLE
fix(certs): include ca-certificates in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ COPY . .
 RUN apk add --no-cache build-base
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -extldflags=-static" -o vortex
 
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
 FROM scratch
 COPY --from=build /build/vortex vortex
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["./vortex", "serve"]


### PR DESCRIPTION
This PR includes the ca-certificates in the produced docker image so TLS connections can be properly validated.