### PR TITLE
ci: add write permissions for coverage badge push

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -6,6 +6,9 @@ name: Go Test
 
 on: [push]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to Go Test workflow so the coverage badge can be pushed to the badges branch
- Fixes `403 Resource not accessible by integration` error on main