### PR TITLE
ci: add CodeQL SAST scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ permissions:
   contents: read
 
 jobs:
+  codeql:
+    permissions:
+      contents: read
+      security-events: write
+    uses: telekom/pubsub-horizon-ci/.github/workflows/codeql.yml@main
+    with:
+      languages: '["go"]'
+
   build:
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Add CodeQL static analysis job using reusable workflow from `pubsub-horizon-ci`
- Scans Go code for security vulnerabilities and code quality issues on every push
- Requires `security-events: write` permission to upload SARIF results

## Test plan

- [ ] `codeql / Analyze (go)` job passes
- [ ] Results visible in Security → Code scanning alerts