### PR TITLE
fix: vortex poison message handling

### DIFF
--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -36,9 +36,9 @@ var (
 func init() {
 	registry = prometheus.NewRegistry()
 
-	messagesConsumedTotal = createCounter("messages_consumed_total", "The total amount of consumed messages")
-	metadataConsumedTotal = createCounter("metadata_consumed_total", "The total amount of consumed metadata")
-	upsertedTotal = createCounter("upserted_total", "The total amount of upserted datasets")
+	messagesConsumedTotal = createCounter("messages_consumed_total", "The total number of consumed Kafka messages of type MESSAGE")
+	metadataConsumedTotal = createCounter("metadata_consumed_total", "The total number of consumed Kafka messages of type METADATA")
+	upsertedTotal = createCounter("upserted_total", "The total number of newly created database documents (inserts via upsert)")
 	skippedMessagesTotal = createCounterVec(
 		"messages_skipped_total",
 		"The total amount of skipped messages grouped by reason",

--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -24,6 +24,7 @@ const Namespace = "vortex"
 var (
 	messagesConsumedTotal prometheus.Counter
 	metadataConsumedTotal prometheus.Counter
+	skippedMessagesTotal  *prometheus.CounterVec
 
 	upsertedTotal prometheus.Counter
 
@@ -37,10 +38,14 @@ func init() {
 
 	messagesConsumedTotal = createCounter("messages_consumed_total", "The total amount of consumed messages")
 	metadataConsumedTotal = createCounter("metadata_consumed_total", "The total amount of consumed metadata")
-	registry.MustRegister(messagesConsumedTotal, metadataConsumedTotal)
-
 	upsertedTotal = createCounter("upserted_total", "The total amount of upserted datasets")
-	registry.MustRegister(upsertedTotal)
+	skippedMessagesTotal = createCounterVec(
+		"messages_skipped_total",
+		"The total amount of skipped messages grouped by reason",
+		[]string{"reason"},
+	)
+	registry.MustRegister(messagesConsumedTotal, metadataConsumedTotal, skippedMessagesTotal, upsertedTotal)
+
 }
 
 func RecordConsumption(message *sarama.ConsumerMessage) {
@@ -74,6 +79,13 @@ func RecordUpserts(datasetCount float64) {
 	upsertedTotal.Add(float64(datasetCount))
 }
 
+func RecordSkipped(reason string) {
+	if !isEnabled() {
+		return
+	}
+	skippedMessagesTotal.WithLabelValues(reason).Inc()
+}
+
 func ExposeMetrics() {
 	http.HandleFunc("/livez", healthHandler("livez"))
 	http.HandleFunc("/readyz", healthHandler("readyz"))
@@ -105,6 +117,14 @@ func createCounter(name string, help string) prometheus.Counter {
 		Name:      name,
 		Help:      help,
 	})
+}
+
+func createCounterVec(name string, help string, labels []string) *prometheus.CounterVec {
+	return promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      name,
+		Help:      help,
+	}, labels)
 }
 
 func isEnabled() bool {

--- a/service/mongo/mongo.go
+++ b/service/mongo/mongo.go
@@ -7,6 +7,7 @@ package mongo
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 	"vortex/service/config"
@@ -184,16 +185,39 @@ func (c *Connection) flush() {
 
 	result, err := collection.BulkWrite(c.connectionContext, c.bulk, opts)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Could not perform bulk-write")
+		var bulkErr mongo.BulkWriteException
+		if !errors.As(err, &bulkErr) || bulkErr.WriteConcernError != nil {
+			// Anything that is not a per-document write error (e.g. lost
+			// connection or an unsatisfied write concern) is treated as fatal,
+			// just like before.
+			log.Fatal().Err(err).Msg("Could not perform bulk-write")
+		}
+
+		// Only duplicate-key violations are skipped: these are poison messages
+		// that will never succeed. Any other write error remains fatal.
+		for _, writeErr := range bulkErr.WriteErrors {
+			if writeErr.Code != 11000 {
+				log.Fatal().Err(err).Msg("Could not perform bulk-write")
+			}
+
+			metrics.RecordSkipped("duplicate_key")
+			log.Warn().
+				Err(err).
+				Int("code", writeErr.Code).
+				Int("index", writeErr.Index).
+				Str("reason", writeErr.Message).
+				Msg("Skipping poison message due to duplicate key violation.")
+		}
 	}
 
 	var fields = map[string]any{
+		"matched":  result.MatchedCount,
 		"upserted": result.UpsertedCount,
 		"inserted": result.InsertedCount,
 		"modified": result.ModifiedCount,
 	}
 	log.Debug().Fields(fields).Msgf("Completed bulk-write")
-	metrics.RecordUpserts(float64(len(c.bulk)))
+	metrics.RecordUpserts(float64(result.MatchedCount + result.UpsertedCount))
 
 	c.bulk = make([]mongo.WriteModel, 0)
 	c.source.CommitOffsets()

--- a/service/mongo/mongo.go
+++ b/service/mongo/mongo.go
@@ -127,6 +127,7 @@ func (c *Connection) upsert(message *sarama.ConsumerMessage) error {
 		if castedId, ok := castedEvent["id"]; ok {
 			filter["event.id"] = castedId
 		} else {
+			// event.id is missing
 			metrics.RecordSkipped("faulty_event")
 			log.Warn().Fields(map[string]any{
 				"partition": message.Partition,
@@ -135,6 +136,7 @@ func (c *Connection) upsert(message *sarama.ConsumerMessage) error {
 			return nil
 		}
 	} else {
+		// event is missing or no object
 		metrics.RecordSkipped("faulty_event")
 		log.Warn().Fields(map[string]any{
 			"partition": message.Partition,
@@ -217,7 +219,7 @@ func (c *Connection) flush() {
 		"modified": result.ModifiedCount,
 	}
 	log.Debug().Fields(fields).Msgf("Completed bulk-write")
-	metrics.RecordUpserts(float64(result.MatchedCount + result.UpsertedCount))
+	metrics.RecordUpserts(float64(result.UpsertedCount))
 
 	c.bulk = make([]mongo.WriteModel, 0)
 	c.source.CommitOffsets()

--- a/service/mongo/mongo.go
+++ b/service/mongo/mongo.go
@@ -7,12 +7,6 @@ package mongo
 import (
 	"context"
 	"encoding/json"
-	"github.com/IBM/sarama"
-	"github.com/rs/zerolog/log"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"sync"
 	"time"
 	"vortex/service/config"
@@ -20,6 +14,13 @@ import (
 	"vortex/service/metrics"
 	"vortex/service/transforms"
 	"vortex/service/utils"
+
+	"github.com/IBM/sarama"
+	"github.com/rs/zerolog/log"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 )
 
 type Connection struct {
@@ -80,7 +81,7 @@ func (c *Connection) Start(processGroup *sync.WaitGroup) {
 		case message := <-c.source.GetOutput():
 			if err := c.upsert(message); err != nil {
 				var fields = utils.GetFieldsFromMessage(message)
-				log.Fatal().Fields(fields).Err(err).Msg("Could not perform update in database")
+				log.Error().Fields(fields).Err(err).Msg("Unexpected error during upsert. Skipping message to avoid blocking partition.")
 			}
 
 		case <-c.connectionContext.Done():
@@ -111,7 +112,12 @@ func (c *Connection) upsert(message *sarama.ConsumerMessage) error {
 	}
 
 	if err := json.Unmarshal(message.Value, &document); err != nil {
-		return err
+		var fields = utils.GetFieldsFromMessage(message)
+		log.Error().
+			Fields(fields).
+			Err(err).
+			Msg("Failed to parse message payload as JSON. Skipping message to avoid blocking partition.")
+		return nil
 	}
 	delete(document, "_id")
 
@@ -136,7 +142,9 @@ func (c *Connection) upsert(message *sarama.ConsumerMessage) error {
 	document["topic"] = message.Topic
 	var transformedDoc, err = transforms.GlobalRegistry.ApplyTransforms(document)
 	if err != nil {
-		log.Fatal().Fields(utils.GetFieldsFromMessage(message)).Err(err).Msg("Could not apply transformations to document")
+		var fields = utils.GetFieldsFromMessage(message)
+		log.Error().Fields(fields).Err(err).Msg("Could not apply transformations to document. Skipping message.")
+		return nil
 	}
 
 	var messageType = utils.GetHeader(message.Headers, "type")

--- a/service/mongo/mongo.go
+++ b/service/mongo/mongo.go
@@ -113,6 +113,7 @@ func (c *Connection) upsert(message *sarama.ConsumerMessage) error {
 
 	if err := json.Unmarshal(message.Value, &document); err != nil {
 		var fields = utils.GetFieldsFromMessage(message)
+		metrics.RecordSkipped("json_parse")
 		log.Error().
 			Fields(fields).
 			Err(err).
@@ -125,6 +126,7 @@ func (c *Connection) upsert(message *sarama.ConsumerMessage) error {
 		if castedId, ok := castedEvent["id"]; ok {
 			filter["event.id"] = castedId
 		} else {
+			metrics.RecordSkipped("faulty_event")
 			log.Warn().Fields(map[string]any{
 				"partition": message.Partition,
 				"offset":    message.Offset,
@@ -132,6 +134,7 @@ func (c *Connection) upsert(message *sarama.ConsumerMessage) error {
 			return nil
 		}
 	} else {
+		metrics.RecordSkipped("faulty_event")
 		log.Warn().Fields(map[string]any{
 			"partition": message.Partition,
 			"offset":    message.Offset,
@@ -143,6 +146,7 @@ func (c *Connection) upsert(message *sarama.ConsumerMessage) error {
 	var transformedDoc, err = transforms.GlobalRegistry.ApplyTransforms(document)
 	if err != nil {
 		var fields = utils.GetFieldsFromMessage(message)
+		metrics.RecordSkipped("transform")
 		log.Error().Fields(fields).Err(err).Msg("Could not apply transformations to document. Skipping message.")
 		return nil
 	}


### PR DESCRIPTION
Fix: Poison messages no longer crash-loop the MongoDB sink
Previously any failed persistence call terminated the process via log.fatal. Since offsets are only committed after a successful flush, a poison message was redelivered indefinitely (crash-loop).

Changes:

- flush(): Only duplicate-key errors (E11000) are skipped, logged, and committed. All other errors (lost connection, write-concern, other write errors) remain Fatal (fail-fast).
- upsert(): JSON-parse, faulty_event, and transform failures now skip the message instead of killing the process.
- New metric vortex_messages_skipped_total (label [reason](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html): json_parse, faulty_event, transform, duplicate_key).